### PR TITLE
Fix multiple listeners on command:beforeCommand event not stopping dispatch

### DIFF
--- a/Library/Phalcon/Script.php
+++ b/Library/Phalcon/Script.php
@@ -107,8 +107,11 @@ class Script extends Injectable
      */
     public function dispatch(Command $command)
     {
-        // If beforeCommand fails abort
-        if ($this->_eventsManager->fire('command:beforeCommand', $command) === false) {
+        $this->_eventsManager->collectResponses(true);
+        $this->_eventsManager->fire('command:beforeCommand', $command);
+
+        // If one of beforeCommand fails, then abort
+        if (false !== array_search(false, $this->_eventsManager->getResponses(), true)) {
             return false;
         }
 


### PR DESCRIPTION
Hi Sacha,

I found a bug in the execution of events in [this line of Script class](https://github.com/SachaMorard/phalcon-console/blob/b528353bd29b03307cc0caa5a54fece6a8fd70b3/Library/Phalcon/Script.php#L111).

Here the `$this->_eventsManager->fire('command:beforeCommand', $command)` call will return true (the last listener call) and then will not stop the command execution if multiple instance listn to this same event.

To reproduce :
* Define two event listeners attached to the event `command`
* Define `beforeCommand` method on both
* Return `false` on the first listener (with higher priority)
* Return `true` for the second listener
* Run a phalcon command

The execution is not stopped while one of listener returned false.

This PR adresses this issue.